### PR TITLE
Updated swagger to contain a separate endpoint for v1.0

### DIFF
--- a/LabFiles/MSGraph-Delegate-Batch.swagger.json
+++ b/LabFiles/MSGraph-Delegate-Batch.swagger.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "MSGraph-Delegate-Batch",
         "description": "",
-        "version": "1.0"
+        "version": "1.1"
     },
     "host": "graph.microsoft.com",
     "basePath": "/",
@@ -23,9 +23,35 @@
                         }
                     }
                 },
-                "summary": "Batch",
+                "summary": "Batch (Beta)",
                 "description": "Execute Batch with Delegate Permission",
                 "operationId": "Batch",
+                "x-ms-visibility": "important",
+                "parameters": [{
+                    "name": "body",
+                    "in": "body",
+                    "required": false,
+                    "schema": {
+                        "type": "object",
+                        "properties": {}
+                    },
+                    "x-ms-visibility": "important"
+                }]
+            }
+        },
+        "/v1.0/$batch": {
+            "post": {
+                "responses": {
+                    "default": {
+                        "description": "default",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "summary": "Batch (1.0)",
+                "description": "Execute Batch with Delegate Permission",
+                "operationId": "BatchV1",
                 "x-ms-visibility": "important",
                 "parameters": [{
                     "name": "body",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1279372/48653506-d1f0ac80-ea59-11e8-9365-69b97f6d8d9f.png)

This swagger update adds /v1.0 endpoint in addition to the original /beta endpoint


![image](https://user-images.githubusercontent.com/1279372/48653521-fa78a680-ea59-11e8-9b4f-ce1d99ea6829.png)

The available actions looks like this.

![image](https://user-images.githubusercontent.com/1279372/48653537-17ad7500-ea5a-11e8-8c4a-faf9a0bb440b.png)
